### PR TITLE
feat: removed `counter` from accepted options in `Totp.GetToken()` and `Totp.AuthURL()` methods

### DIFF
--- a/__tests__/totp.test.ts
+++ b/__tests__/totp.test.ts
@@ -175,14 +175,10 @@ describe( 'Totp.AuthURL()', () => {
 		const secrets = Totp.GetSecrets( {
 			secret: { key: hexSecret }
 		} )
-		const counter = Totp.Counter( {
-			time: new Date( '2024-12-13T16:00:00.000Z' ).getTime() / 1000
-		} )
 
 		const url = new URL( Totp.AuthURL( {
 			label	: 'example@email.com',
 			digits	: 8,
-			counter	: counter,
 			period	: 60,
 			secret	: { key: hexSecret },
 			issuer	: 'Issuer',

--- a/src/Otp.ts
+++ b/src/Otp.ts
@@ -180,7 +180,7 @@ export class Otp
 				algorithm	= Otp.Algorithm,
 				encoding	= Otp.Encoding,
 			},
-			digits = Otp.Digits, type, label, issuer, counter
+			digits = Otp.Digits, type, label, issuer
 		} = options
 
 		let { key }			= options.secret
@@ -199,7 +199,7 @@ export class Otp
 		if ( issuer ) query.issuer = issuer
 
 		if ( type === 'hotp' ) {
-			query.counter = counter
+			query.counter = options.counter
 		}
 		if ( type === 'totp' && options.period ) {
 			query.period = options.period

--- a/src/Totp.ts
+++ b/src/Totp.ts
@@ -56,12 +56,11 @@ export class Totp extends Otp
 	 */
 	static GetToken( options: OTP.TOTP.GetTokenOptions )
 	{
-		const {
-			counter = Totp.Counter( options ), ...rest
-		} = options
-
 		return (
-			Hotp.GetToken( { ...rest, counter } )
+			Hotp.GetToken( {
+				...options,
+				counter: Totp.Counter( options ) }
+			)
 		)
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,7 +129,7 @@ export namespace OTP
 			{
 				/** The OTP type needed to distinguish whether the key will be used for counter-based HOTP or for TOTP. */
 				type: 'totp'
-			} & Pick<TOTP.CounterOptions, 'period'> & Pick<TOTP.GetTokenOptions, 'counter'>
+			} & Pick<TOTP.CounterOptions, 'period'>
 		)
 	)
 	
@@ -258,14 +258,14 @@ export namespace OTP
 		 * Defines the options required to generate a TOTP token.
 		 * 
 		 */
-		export type GetTokenOptions = HOTP.GetTokenOptions & CounterOptions
+		export type GetTokenOptions = Omit<HOTP.GetTokenOptions, 'counter'> & TOTP.CounterOptions
 		
 
 		/**
 		 * Options for verifying a TOTP token and determining the time-step delta.
 		 * 
 		 */
-		export interface GetDeltaOptions extends GetTokenOptions, HOTP.GetDeltaOptions
+		export interface GetDeltaOptions extends TOTP.GetTokenOptions, HOTP.GetDeltaOptions
 		{
 			/**
 			 * The number of time-step counter values to check before and after the expected counter during TOTP token verification.


### PR DESCRIPTION
The counter will be always generated based on the given `time`