### PR TITLE
fix: removed `counter` from accepted options in `Totp.GetDelta()` method.

### DIFF
--- a/src/Hotp.ts
+++ b/src/Hotp.ts
@@ -43,7 +43,7 @@ export class Hotp extends Otp
 	 * @param	options The TOTP options. @see {@link OTP.TOTP.GetDeltaOptions}
 	 * @returns	The delta number, null otherwise.
 	 */
-	static GetDelta( options: OTP.TOTP.GetDeltaOptions, twoSidedWindow?: boolean ): number | null
+	static GetDelta( options: OTP.HOTP.GetDeltaOptions, twoSidedWindow?: boolean ): number | null
 	
 	
 	/**

--- a/src/Totp.ts
+++ b/src/Totp.ts
@@ -38,12 +38,11 @@ export class Totp extends Otp
 	 */
 	static GetDelta( options: OTP.TOTP.GetDeltaOptions )
 	{
-		const {
-			counter = Totp.Counter( options ), ...rest
-		} = options
-
 		return (
-			Hotp.GetDelta( { ...rest, counter }, true )
+			Hotp.GetDelta( {
+				...options,
+				counter: Totp.Counter( options )
+			}, true )
 		)
 	}
 
@@ -59,8 +58,8 @@ export class Totp extends Otp
 		return (
 			Hotp.GetToken( {
 				...options,
-				counter: Totp.Counter( options ) }
-			)
+				counter: Totp.Counter( options )
+			} )
 		)
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -265,7 +265,7 @@ export namespace OTP
 		 * Options for verifying a TOTP token and determining the time-step delta.
 		 * 
 		 */
-		export interface GetDeltaOptions extends TOTP.GetTokenOptions, HOTP.GetDeltaOptions
+		export interface GetDeltaOptions extends TOTP.GetTokenOptions, Omit<HOTP.GetDeltaOptions, 'counter'>
 		{
 			/**
 			 * The number of time-step counter values to check before and after the expected counter during TOTP token verification.


### PR DESCRIPTION
counter is always generated based on the given `time`